### PR TITLE
Implement cached texture uploads utilizing `PF_State`

### DIFF
--- a/include/Vulkanator.hpp
+++ b/include/Vulkanator.hpp
@@ -8,6 +8,7 @@
 #include <AEConfig.h>
 
 #include <AE_Effect.h>
+#include <AE_EffectSuites.h>
 #include <entry.h>
 
 #include "VulkanConfig.hpp"
@@ -108,6 +109,7 @@ struct SequenceParams
 		vk::ImageCreateInfo InputImageInfoCache  = {};
 		vk::ImageCreateInfo OutputImageInfoCache = {};
 
+		PF_State               InputImageState  = {};
 		vk::UniqueImage        InputImage       = {};
 		vk::UniqueDeviceMemory InputImageMemory = {};
 

--- a/include/Vulkanator.hpp
+++ b/include/Vulkanator.hpp
@@ -104,9 +104,10 @@ struct SequenceParams
 		vk::UniqueBuffer       StagingBuffer       = {};
 		vk::UniqueDeviceMemory StagingBufferMemory = {};
 
-		// We use these structs so that we can easily "==" compare the image in
-		// the cache with any new requests coming in
-		vk::ImageCreateInfo InputImageInfoCache  = {};
+		// We use ImageCreateInfo so that we can easily "==" compare the image
+		// in the cache with the image being rendered for the current frame
+		// in the case that we can re-use the memory directly rather than
+		// allocating a new buffer
 		vk::ImageCreateInfo OutputImageInfoCache = {};
 
 		PF_State               InputImageState  = {};

--- a/source/Vulkanator.cpp
+++ b/source/Vulkanator.cpp
@@ -1277,7 +1277,7 @@ PF_Err SmartRender(
 	InputImageInfo.tiling      = vk::ImageTiling::eOptimal;
 	InputImageInfo.usage
 		= vk::ImageUsageFlagBits::eTransferSrc
-		| vk::ImageUsageFlagBits::eTransferDst // Will be trasnferring from the
+		| vk::ImageUsageFlagBits::eTransferDst // Will be transferring from the
 											   // staging buffer into this one
 		| vk::ImageUsageFlagBits::eSampled; // Will be sampling from this image
 	InputImageInfo.sharingMode   = vk::SharingMode::eExclusive;
@@ -1294,6 +1294,8 @@ PF_Err SmartRender(
 	));
 
 	// Compare hash of the currently uploaded texture against the cached one
+	// This primarily helps redundantly uploading the input texture in the case
+	// of still-images and hold-frames
 	A_Boolean InputImageStateIsSame = false;
 	ERR(suites.ParamUtilsSuite3()->PF_AreStatesIdentical(
 		in_data->effect_ref, &SequenceParam->Cache.InputImageState, &CurState,
@@ -1316,8 +1318,7 @@ PF_Err SmartRender(
 				  InputImageInfo, vk::MemoryPropertyFlagBits::eDeviceLocal
 			)
 				  .value();
-		SequenceParam->Cache.InputImageInfoCache = InputImageInfo;
-		SequenceParam->Cache.InputImageState     = CurState;
+		SequenceParam->Cache.InputImageState = CurState;
 	}
 
 	// This provides a mapping between the image contents and the staging
@@ -1348,8 +1349,6 @@ PF_Err SmartRender(
 		0, 1,                            // A single mipmap, mipmap 0
 		0, 1                             // A single image layer, layer 0
 	);
-
-	SequenceParam->Cache.InputImageInfoCache = InputImageInfo;
 
 	vk::UniqueImageView InputImageView = {};
 	if( auto ImageViewResult


### PR DESCRIPTION
Uses `PF_State` to conservatively upload the InputTexture only when needed. This optimizes the case where the source input layer is a static image, a time-remapped video, or a low-framerate image.

Ex, in the case of a static image, the source texture is only uploaded once, keeping track of its `PF_State`, and subsequent render requests will re-use this uploaded texture.

The coherency of `PF_State` needs to be validated a bit.

Resolves #5 