### PR TITLE
Refactor vulkan structures to aggregate initialization

### DIFF
--- a/include/VulkanConfig.hpp
+++ b/include/VulkanConfig.hpp
@@ -6,4 +6,8 @@
 // Rather than using exceptions, we use error code results so we can
 // specially-handle specific types of vulkan errors;
 #define VULKAN_HPP_NO_EXCEPTIONS
+
+// Used to allow aggregate initialization for structs
+#define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
+
 #include <vulkan/vulkan.hpp>


### PR DESCRIPTION
Inline definitions of these structures do not make it easy to determine what argument is going where. With aggregate initialization, each struct member is being assigned explicitly. This also allows many structures to be `const` or `static`.  This also allows many structures to document themselves now that member names are visible at the site of creation.

This uses `VULKAN_HPP_NO_STRUCT_CONSTRUCTORS` to disable the custom constructor from `struct`s.